### PR TITLE
fix: config limit used for trigger collection, lead to potential underflow

### DIFF
--- a/src/store/assertion_contract_extractor.rs
+++ b/src/store/assertion_contract_extractor.rs
@@ -128,7 +128,7 @@ pub fn extract_assertion_contract(
             transact_to: TxKind::Call(ASSERTION_CONTRACT),
             caller: CALLER,
             data: triggersCall::SELECTOR.into(),
-            gas_limit: config.assertion_gas_limit - result_and_state.result.gas_used(),
+            gas_limit: DEPLOYMENT_GAS_LIMIT - result_and_state.result.gas_used(),
             #[cfg(feature = "optimism")]
             optimism: create_optimism_fields(),
             ..Default::default()


### PR DESCRIPTION
The higher deployment gas value is used for deployment transactions, but the `triggers()` execution used the `config.assertion_gas_limit - deployment_gas`. This resulted in an underflow when the gas in deployment exceeds the configured assertion gas limit. 

This limits the total gas consumption in deployment and trigger recording to be the `DEPLOYMENT_GAS_LIMIT`